### PR TITLE
ci: upgrade github actions versions

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Clean cache for closed branch
       run: |
@@ -61,7 +61,7 @@ jobs:
       build-matrix: ${{ steps.infos.outputs.BUILD_MATRIX }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Get variables
       id: infos
@@ -78,7 +78,7 @@ jobs:
         images: ${{ fromJSON(needs.infos.outputs.build-matrix) }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Get repository owner and name
       id: image-infos

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
       registry-user: ${{ steps.infos.outputs.REGISTRY_USER }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Get variables
       id: infos
@@ -82,13 +82,13 @@ jobs:
         images: ${{ fromJSON(needs.infos.outputs.build-matrix) }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Cache Docker layers
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: /tmp/.buildx-cache
         key: buildx-${{ runner.os }}-${{ runner.arch }}-${{ matrix.images.name }}-${{ hashFiles('src/**') }}
@@ -96,11 +96,11 @@ jobs:
           buildx-${{ runner.os }}-${{ runner.arch }}-${{ matrix.images.name }}-
 
     - name: Set up QEMU (for multi platform build)
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       if: ${{ inputs.USE_QEMU }}
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ needs.infos.outputs.registry-domain }}
         username: ${{ github.actor }}
@@ -109,7 +109,7 @@ jobs:
 
     - name: Build and push docker image
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ matrix.images.build.context }}
         file: ${{ matrix.images.build.dockerfile }}
@@ -138,7 +138,7 @@ jobs:
         touch "/tmp/digests/${{ matrix.images.name }}/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: digests-${{ matrix.images.name }}-${{ inputs.MULTI_ARCH && inputs.USE_QEMU && 'linux-amd64_linux-arm64' || (contains(runner.arch, 'ARM') && 'linux-arm64' || 'linux-amd64') }}
         path: /tmp/digests/${{ matrix.images.name }}/*
@@ -156,18 +156,18 @@ jobs:
         images: ${{ fromJSON(needs.infos.outputs.build-matrix) }}
     steps:
     - name: Download digests
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: digests-${{ matrix.images.name }}-*
         path: /tmp/digests/${{ matrix.images.name }}
         merge-multiple: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ needs.infos.outputs.registry-domain }}/${{ needs.infos.outputs.registry-user }}/${{ matrix.images.name }}
         tags: |
@@ -180,7 +180,7 @@ jobs:
           type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ needs.infos.outputs.registry-domain }}
         username: ${{ github.actor }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
@@ -38,7 +38,7 @@ jobs:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "${{ inputs.NODE_VERSION }}"
 
@@ -48,7 +48,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache node files
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.pnpm-store.outputs.STORE_PATH }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -39,7 +39,7 @@ jobs:
       publish-matrix: ${{ steps.infos.outputs.PUBLISH_MATRIX }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Get variables
       id: infos
@@ -60,7 +60,7 @@ jobs:
         packages: ${{ fromJSON(needs.infos.outputs.publish-matrix) }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.ref }}
 
@@ -88,12 +88,11 @@ jobs:
         echo "REMOTE=$REMOTE" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
       with:
         node-version: "${{ inputs.NODE_VERSION }}"
         registry-url: "https://registry.npmjs.org"
-        always-auth: true
 
     - name: Get pnpm store directory
       if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
@@ -103,7 +102,7 @@ jobs:
 
     - name: Cache node files
       if: ${{ steps.check-version.outputs.REMOTE == 'false' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.pnpm-store.outputs.STORE_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       patch-tag: ${{ steps.release.outputs.patch }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Release new version
       uses: googleapis/release-please-action@v4

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -33,7 +33,7 @@ jobs:
       build-matrix: ${{ steps.infos.outputs.BUILD_MATRIX }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Get variables
       id: infos
@@ -50,11 +50,11 @@ jobs:
         images: ${{ fromJSON(needs.infos.outputs.build-matrix) }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker buildx
       if: ${{ matrix.images.build != false }}
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Run Trivy vulnerability scanner on images
       uses: aquasecurity/trivy-action@0.35.0
@@ -80,7 +80,7 @@ jobs:
     - infos
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run Trivy vulnerability scanner on config files
       uses: aquasecurity/trivy-action@0.35.0

--- a/.github/workflows/tests-cli.yml
+++ b/.github/workflows/tests-cli.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
@@ -51,7 +51,7 @@ jobs:
         bun-version: "${{ inputs.BUN_VERSION }}"
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "${{ inputs.NODE_VERSION }}"
 
@@ -61,7 +61,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache node files
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.pnpm-store.outputs.STORE_PATH }}

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
@@ -45,7 +45,7 @@ jobs:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "${{ inputs.NODE_VERSION }}"
 
@@ -55,7 +55,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache node files
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.pnpm-store.outputs.STORE_PATH }}
@@ -70,7 +70,7 @@ jobs:
       run: pnpm run test:cov
 
     - name: Upload vitest coverage artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: unit-tests-coverage
         path: |
@@ -103,12 +103,12 @@ jobs:
     if: ${{ needs.check-secrets.outputs.run-scan == 'true' }}
     steps:
     - name: Checks-out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: unit-tests-coverage
         path: ./coverage
@@ -121,7 +121,7 @@ jobs:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "${{ inputs.NODE_VERSION }}"
 
@@ -131,7 +131,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache node files
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.pnpm-store.outputs.STORE_PATH }}


### PR DESCRIPTION
## Description

Upgrade all GitHub Actions used across CI workflows to their latest major versions.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/cache` | `@v4` | `@v5` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/setup-qemu-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v6` | `@v7` |
| `docker/metadata-action` | `@v5` | `@v6` |

Also removed the `always-auth` input from `actions/setup-node` in `npm.yml`, as it was dropped in v6. Authentication still works via `registry-url` + `NODE_AUTH_TOKEN`.

## Type of change

- [x] Other (please describe): CI/CD maintenance — GitHub Actions version upgrades

## How Has This Been Tested?

Versions verified against each action's latest GitHub release. No logic change, only action version pins updated.

**Test Configuration**:
- Toolchain: GitHub Actions

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings