### PR TITLE
fix: run build:clean before building so stale dist/ can't ship

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "pnpm run build:types && pnpm run build:vite",
+    "build": "pnpm run build:clean && pnpm run build:types && pnpm run build:vite",
     "build:clean": "rimraf ./dist ./types ./tsconfig.tsbuildinfo",
     "build:docker": "docker build --tag tobi-or-not/docpress --target prod .",
     "build:types": "tsc",


### PR DESCRIPTION
## Summary
The manually-published `@tobi-or-not/docpress@0.8.2` on npm is missing the "skip sources instead of crashing" fix (#66), even though that fix is present in the `v0.8.2` tag's source. `pnpm run build` never ran `build:clean` first, so a stale `dist/cli.js`/`tsconfig.tsbuildinfo` from before the fix survived the rebuild during that publish.

`build` now depends on `build:clean` so this class of bug can't recur - every build starts from a clean `dist/`/`types`/`tsconfig.tsbuildinfo`.

Verified locally: a clean `pnpm run build` on this branch produces a `dist/cli.js` that contains the fix's log line ("No markdown files found for repository...").

Once this merges, release-please should cut 0.8.3, and the now-fixed CI pipeline (Corepack pnpm resolution + OIDC trusted publishing) should publish a correctly-built version automatically.

## Test plan
- [x] Unit tests pass (216/216)
- [x] Verified `dist/cli.js` contains the fix after a clean local build
- [ ] Confirm 0.8.3 auto-publishes correctly once merged