### PR TITLE
fix(npm): guard husky prepare script so bun publish does not fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev:clean": "rimraf ./docpress && bun run dev",
     "format": "eslint . --fix",
     "lint": "eslint .",
-    "prepare": "husky",
+    "prepare": "husky || true",
     "start": "./bin/docpress.js",
     "start:docker": "docker run --name docpress --rm -v $(pwd)/docpress:/app/docpress:rw tobi-or-not/docpress",
     "stop:docker": "docker rm --force docpress",


### PR DESCRIPTION
## Summary
- `bun publish` runs the `prepare` lifecycle script but, unlike `bun run prepare`, does not prepend `node_modules/.bin` to `PATH`, so `husky` resolves as "command not found" (exit 127) even though it's an installed devDependency.
- This broke the npm publish job for the just-cut v0.9.0 release ([failed run](https://github.com/this-is-tobi/docpress/actions/runs/28711394834/job/85145440759)) — the GitHub release/tag exists but the version never reached the npm registry.
- Guarded the script as `"prepare": "husky || true"`, the standard pattern recommended by husky for exactly this kind of environment/PATH mismatch.

Reproduced locally with `bun publish --dry-run` against a full `bun install --frozen-lockfile` (devDependencies included): fails without the guard, packs successfully with it.

## Note on v0.9.0
This branch doesn't retroactively publish v0.9.0 to npm — merging it lets release-please cut the next release (v0.9.1) with the fix included, which will publish correctly. v0.9.0 will remain a GitHub release/tag with no npm counterpart. Let me know if you'd rather have v0.9.0 manually published to fill that gap instead.

## Test plan
- [x] `bun run test` — 232 passing
- [x] `bun run lint` — clean
- [x] Reproduced the failure and the fix locally via `bun publish --dry-run`
- [ ] CI green on this PR