### PR TITLE
feat: vitepress lastUpdated support & fix internal doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ To ensure that the program functions correctly, please follow these conventions:
 
 - Any inline link in the `./README.md` file that does not point to `./docs/**` will be replaced with the corresponding Git provider link.
 - Similarly, any inline link in the `./docs/*.md` files that does not reference `./docs/**` will also be replaced with the appropriate Git provider link.
+- Relative links between markdown files are rewritten to follow the file renaming rules, so `[profiles](./04-profiles.md#anchor)` will be rewritten to `[profiles](./profiles.md#anchor)` to match the renamed target file.
 
 ### Project descriptions
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
                                        Values should be "github" or "gitlab".
                                        (default: "github")
   -h, --help                           display help for command
+  -l, --last-updated                   Whether or not to inject each page's last Git commit date as Vitepress "lastUpdated" frontmatter.
   -p, --extra-header-pages <string>    List of comma separated additional files or directories to process Vitepress header pages.
   -r, --repos-filter <string>          List of comma separated repositories to retrieve from Git provider. Default to all user's public repositories.
   -t, --extra-theme <string>           List of comma separated additional files or directories to use as Vitepress theme.

--- a/src/commands/fetch.spec.ts
+++ b/src/commands/fetch.spec.ts
@@ -136,6 +136,19 @@ describe('main', () => {
     })
   })
 
+  it('should forward the lastUpdated flag to fetchDoc', async () => {
+    const mockOpts = {
+      usernames: ['testUser'],
+      branch: 'main',
+      gitProvider: 'github' as const,
+      lastUpdated: true,
+    }
+
+    await main(mockOpts)
+
+    expect(fetchDoc).toHaveBeenCalledWith(expect.objectContaining({ lastUpdated: true }))
+  })
+
   it('should create the docpress directory before fetching', async () => {
     const mockOpts = {
       usernames: ['testUser'],
@@ -154,11 +167,14 @@ describe('fetchOpts', () => {
   it('should configure options with correct descriptions and default values', () => {
     const branchOption = fetchOpts.find(opt => opt.flags.includes('--branch'))
     const gitProviderOption = fetchOpts.find(opt => opt.flags.includes('--git-provider'))
+    const lastUpdatedOption = fetchOpts.find(opt => opt.flags.includes('--last-updated'))
 
     expect(branchOption?.description).toBe(configSchema.shape.branch.description || '')
     expect(branchOption?.defaultValue).toBe('main')
 
     expect(gitProviderOption?.description).toBe(configSchema.shape.gitProvider.description || '')
     expect(gitProviderOption?.defaultValue).toBe('github')
+
+    expect(lastUpdatedOption?.description).toBe(configSchema.shape.lastUpdated.description || '')
   })
 })

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -21,6 +21,7 @@ export const fetchOpts = [
     .default(configSchema.shape.branch.def.defaultValue),
   createOption('-g, --git-provider <string>', configSchema.shape.gitProvider.description)
     .default(configSchema.shape.gitProvider.def.defaultValue),
+  createOption('-l, --last-updated', configSchema.shape.lastUpdated.description),
   createOption('-r, --repos-filter <string>', configSchema.shape.reposFilter.description),
 ]
 
@@ -40,7 +41,7 @@ export const fetchCmd = addOptions(createCommand(cmdName), [...fetchOpts, ...glo
  * @param opts - Validated fetch options
  */
 export async function main(opts: FetchOpts) {
-  const { usernames, reposFilter, token, branch, gitProvider } = opts
+  const { usernames, reposFilter, token, branch, gitProvider, lastUpdated } = opts
   log(`\n-> Start fetching documentation files. This may take a moment, especially for larger repositories.`, 'info')
 
   createDir(DOCPRESS_DIR, { clean: true })
@@ -49,6 +50,6 @@ export async function main(opts: FetchOpts) {
     const finalRF = usernames.length > 1
       ? reposFilter?.filter((rf: string) => rf.replace(/^!/, '').startsWith(`${username}/`)).map((rf: string) => rf.replace(`${username}/`, ''))
       : reposFilter
-    await fetchDoc({ username, branch, reposFilter: finalRF, gitProvider, token })
+    await fetchDoc({ username, branch, reposFilter: finalRF, gitProvider, token, lastUpdated })
   }
 }

--- a/src/commands/prepare.spec.ts
+++ b/src/commands/prepare.spec.ts
@@ -123,6 +123,11 @@ describe('main', () => {
     expect(prepareDoc).toHaveBeenCalled()
   })
 
+  it('should forward the lastUpdated flag to prepareDoc', async () => {
+    await main({ ...mockOpts, lastUpdated: true })
+    expect(prepareDoc).toHaveBeenCalledWith(expect.objectContaining({ lastUpdated: true }))
+  })
+
   // it('should log the start message and call getUserInfos and getUserRepos', async () => {
   //   await main(mockOpts)
   //   expect(log).toHaveBeenCalledWith(

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -43,11 +43,11 @@ export const prepareCmd = addOptions(createCommand(cmdName), [...prepareOpts, ..
  * @param opts - Validated prepare options
  */
 export async function main(opts: PrepareOpts) {
-  const { extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, token, usernames, websiteTitle, websiteTagline } = opts
+  const { extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, lastUpdated, token, usernames, websiteTitle, websiteTagline } = opts
   log(`\n-> Start transform files to prepare Vitepress build.`, 'info')
 
   createDir(dirname(VITEPRESS_CONFIG), { clean: true })
   for (const username of usernames) {
-    await prepareDoc({ extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, token, username, websiteTitle, websiteTagline })
+    await prepareDoc({ extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, lastUpdated, token, username, websiteTitle, websiteTagline })
   }
 }

--- a/src/lib/fetch.spec.ts
+++ b/src/lib/fetch.spec.ts
@@ -180,8 +180,32 @@ describe('getDoc', () => {
       repos[0].docpress.projectPath,
       repos[0].docpress.branch,
       repos[0].docpress.includes,
+      undefined,
     )
-    expect(cloneRepo).not.toHaveBeenCalledWith(repos[1].name, expect.anything(), expect.anything(), expect.anything(), expect.anything())
+    expect(cloneRepo).not.toHaveBeenCalledWith(repos[1].name, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything())
+  })
+
+  it('should forward the lastUpdated flag to cloneRepo', async () => {
+    const repos = [
+      {
+        name: 'repo1',
+        clone_url: 'https://github.com/testUser/repo1',
+        fork: false,
+        private: false,
+        docpress: { projectPath: '/path/to/repo1', branch: 'main', includes: ['README.md'] },
+      },
+    ] as unknown as EnhancedRepository[]
+
+    await getDoc(repos, ['repo1'], true)
+
+    expect(cloneRepo).toHaveBeenCalledWith(
+      repos[0].name,
+      repos[0].clone_url,
+      repos[0].docpress.projectPath,
+      repos[0].docpress.branch,
+      repos[0].docpress.includes,
+      true,
+    )
   })
 
   it('should warn if no repositories are provided', async () => {
@@ -211,6 +235,7 @@ describe('getDoc', () => {
       repos[0].docpress.projectPath,
       repos[0].docpress.branch,
       repos[0].docpress.includes,
+      undefined,
     )
   })
 })
@@ -340,6 +365,22 @@ describe('fetchDoc', () => {
       branch: mockFetchOpts.branch,
     })
     expect(getGitlabInfos).not.toHaveBeenCalled()
+  })
+
+  it('should forward the lastUpdated flag down through generateInfos/getDoc to cloneRepo', async () => {
+    ;(getInfos as any).mockResolvedValue({ user: mockUser, repos: mockRepos, branch: 'main' })
+    ;(checkHttpStatus as any).mockResolvedValue(200)
+
+    await fetchDoc({ ...mockFetchOpts, lastUpdated: true })
+
+    expect(cloneRepo).toHaveBeenCalledWith(
+      mockRepos[0].name,
+      mockRepos[0].clone_url,
+      expect.any(String),
+      'main',
+      expect.any(Array),
+      true,
+    )
   })
 
   it('should use the gitlab provider when configured', async () => {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -82,12 +82,13 @@ export async function checkDoc(urls: ProviderUrls) {
  * @param options.reposFilter - Optional filter for repositories
  * @param options.gitProvider - Git provider used to retrieve data
  * @param options.token - Git provider API token
+ * @param options.lastUpdated - Whether or not to inject each page's last Git commit date as frontmatter
  */
-export async function fetchDoc({ username, branch, reposFilter, gitProvider, token }: FetchOptsUser) {
+export async function fetchDoc({ username, branch, reposFilter, gitProvider, token, lastUpdated }: FetchOptsUser) {
   const getProviderInfos = gitProvider === 'gitlab' ? getGitlabInfos : getInfos
   await getProviderInfos({ username, token, branch })
     .then(async ({ user, repos, branch }) => generateInfos(user, repos, branch, reposFilter, gitProvider))
-    .then(async ({ repos }) => getDoc(repos, reposFilter))
+    .then(async ({ repos }) => getDoc(repos, reposFilter, lastUpdated))
 }
 
 /**
@@ -178,8 +179,9 @@ export async function generateInfos(user: Awaited<ReturnType<typeof getInfos>>['
  *
  * @param repos - List of enhanced repositories
  * @param reposFilter - Optional filter for repositories
+ * @param lastUpdated - Whether or not to inject each page's last Git commit date as frontmatter
  */
-export async function getDoc(repos?: EnhancedRepository[], reposFilter?: FetchOpts['reposFilter']) {
+export async function getDoc(repos?: EnhancedRepository[], reposFilter?: FetchOpts['reposFilter'], lastUpdated?: boolean) {
   if (!repos) {
     log(`   No repository respect docpress rules.`, 'warn')
     return
@@ -189,7 +191,7 @@ export async function getDoc(repos?: EnhancedRepository[], reposFilter?: FetchOp
     repos
       .filter(repo => !isRepoFiltered(repo, reposFilter))
       .map(async (repo) => {
-        await cloneRepo(repo.name, repo.clone_url as string, repo.docpress.projectPath, repo.docpress.branch, repo.docpress.includes)
+        await cloneRepo(repo.name, repo.clone_url as string, repo.docpress.projectPath, repo.docpress.branch, repo.docpress.includes, lastUpdated)
       }),
   )
 }

--- a/src/lib/git.spec.ts
+++ b/src/lib/git.spec.ts
@@ -2,15 +2,18 @@ import { appendFileSync, cpSync, rmSync } from 'node:fs'
 import { Octokit } from '@octokit/rest'
 import { simpleGit } from 'simple-git'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDir } from '../utils/functions.js'
+import { addLastUpdatedFrontmatter, createDir, getMdFiles } from '../utils/functions.js'
 import { log } from '../utils/logger.js'
-import { cloneRepo, getContributors, getInfos } from './git.js'
+import { applyLastUpdated, cloneRepo, getContributors, getInfos } from './git.js'
 import type { EnhancedRepository } from './fetch.js'
 
 vi.mock('@octokit/rest')
 vi.mock('simple-git')
 vi.mock('node:fs')
-vi.mock('node:path', () => ({ resolve: vi.fn((...args) => args.join('/')) }))
+vi.mock('node:path', () => ({
+  resolve: vi.fn((...args) => args.join('/')),
+  relative: vi.fn((from: string, to: string) => to.replace(`${from}/`, '')),
+}))
 vi.mock('../utils/functions.js')
 vi.mock('../utils/logger.js')
 
@@ -191,6 +194,39 @@ describe('getContributors', () => {
   })
 })
 
+describe('applyLastUpdated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should inject the last commit date for each markdown file', async () => {
+    const mockLog = vi.fn()
+      .mockResolvedValueOnce({ latest: { date: '2024-05-01T12:00:00+00:00' } })
+      .mockResolvedValueOnce({ latest: null })
+    const mockGit = { log: mockLog }
+
+    ;(getMdFiles as any).mockReturnValue(['testDir/docs/a.md', 'testDir/docs/b.md'])
+
+    await applyLastUpdated(mockGit as any, 'testDir', 'repo1')
+
+    expect(mockLog).toHaveBeenCalledWith({ file: 'docs/a.md', maxCount: 1 })
+    expect(mockLog).toHaveBeenCalledWith({ file: 'docs/b.md', maxCount: 1 })
+    expect(addLastUpdatedFrontmatter).toHaveBeenCalledWith('testDir/docs/a.md', '2024-05-01T12:00:00+00:00')
+    expect(addLastUpdatedFrontmatter).toHaveBeenCalledTimes(1)
+  })
+
+  it('should warn and continue when git log fails for a file', async () => {
+    const mockGit = { log: vi.fn().mockRejectedValueOnce(new Error('boom')) }
+
+    ;(getMdFiles as any).mockReturnValue(['testDir/docs/a.md'])
+
+    await applyLastUpdated(mockGit as any, 'testDir', 'repo1')
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining(`Unable to get last commit date for 'docs/a.md' in repository 'repo1'`), 'warn')
+    expect(addLastUpdatedFrontmatter).not.toHaveBeenCalled()
+  })
+})
+
 describe('cloneRepo', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -256,5 +292,39 @@ describe('cloneRepo', () => {
     await cloneRepo('repo1', 'https://github.com/testUser/repo.git', 'testDir', 'main', ['docs'])
 
     expect(log).toHaveBeenCalledWith(expect.stringContaining(`Error when cloning repository: ${gitError}`), 'error')
+  })
+
+  it('should look up and inject last updated dates when lastUpdated is enabled', async () => {
+    const mockGit = {
+      init: vi.fn().mockReturnThis(),
+      addConfig: vi.fn().mockReturnThis(),
+      addRemote: vi.fn().mockReturnThis(),
+      pull: vi.fn().mockReturnThis(),
+      log: vi.fn().mockResolvedValue({ latest: { date: '2024-05-01T12:00:00+00:00' } }),
+    }
+
+    ;(simpleGit as any).mockImplementation(() => mockGit)
+    ;(getMdFiles as any).mockReturnValue(['testDir/docs/file1.md'])
+
+    await cloneRepo('repo1', 'https://github.com/testUser/repo.git', 'testDir', 'main', ['docs/file1.md'], true)
+
+    expect(mockGit.log).toHaveBeenCalledWith({ file: 'docs/file1.md', maxCount: 1 })
+    expect(addLastUpdatedFrontmatter).toHaveBeenCalledWith('testDir/docs/file1.md', '2024-05-01T12:00:00+00:00')
+  })
+
+  it('should not look up last updated dates when lastUpdated is disabled', async () => {
+    const mockGit = {
+      init: vi.fn().mockReturnThis(),
+      addConfig: vi.fn().mockReturnThis(),
+      addRemote: vi.fn().mockReturnThis(),
+      pull: vi.fn().mockReturnThis(),
+      log: vi.fn(),
+    }
+
+    ;(simpleGit as any).mockImplementation(() => mockGit)
+
+    await cloneRepo('repo1', 'https://github.com/testUser/repo.git', 'testDir', 'main', ['docs/file1.md'])
+
+    expect(mockGit.log).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,10 +1,11 @@
 import { appendFileSync, cpSync, rmSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { relative, resolve } from 'node:path'
 import { Octokit } from '@octokit/rest'
 import { simpleGit } from 'simple-git'
+import type { SimpleGit } from 'simple-git'
 import type { GlobalOpts } from '../schemas/global.js'
 import type { FetchOpts } from '../schemas/fetch.js'
-import { createDir } from '../utils/functions.js'
+import { addLastUpdatedFrontmatter, createDir, getMdFiles } from '../utils/functions.js'
 import { log } from '../utils/logger.js'
 import type { EnhancedRepository } from './fetch.js'
 
@@ -93,6 +94,30 @@ export async function getContributors({
 }
 
 /**
+ * Injects each markdown file's last Git commit date as a "lastUpdated" frontmatter field
+ * Reads the commit history straight from the local clone, so no Git provider API call is
+ * needed and no rate limit is spent, regardless of how many files or repositories are processed
+ *
+ * @param git - Simple-git instance scoped to the cloned repository, with history still intact
+ * @param projectDir - Directory containing the cloned repository
+ * @param name - Repository name, used for logging
+ */
+export async function applyLastUpdated(git: SimpleGit, projectDir: string, name: string) {
+  for (const file of getMdFiles([projectDir])) {
+    const filePath = relative(projectDir, file)
+
+    try {
+      const { latest } = await git.log({ file: filePath, maxCount: 1 })
+      if (latest?.date) {
+        addLastUpdatedFrontmatter(file, latest.date)
+      }
+    } catch (error) {
+      log(`   Unable to get last commit date for '${filePath}' in repository '${name}'. Error : ${error}`, 'warn')
+    }
+  }
+}
+
+/**
  * Clones a repository with sparse checkout
  *
  * @param name - Repository name
@@ -100,8 +125,9 @@ export async function getContributors({
  * @param projectDir - Directory to clone into
  * @param branch - Branch to clone
  * @param includes - Patterns to include in sparse checkout
+ * @param lastUpdated - Whether or not to inject each page's last Git commit date as frontmatter
  */
-export async function cloneRepo(name: string, url: string, projectDir: string, branch: string, includes: string[]) {
+export async function cloneRepo(name: string, url: string, projectDir: string, branch: string, includes: string[], lastUpdated?: boolean) {
   createDir(projectDir, { clean: true })
 
   try {
@@ -119,6 +145,10 @@ export async function cloneRepo(name: string, url: string, projectDir: string, b
 
     log(`   Clone repository '${name}'.`, 'info')
     await git.pull('origin', branch)
+
+    if (lastUpdated) {
+      await applyLastUpdated(git, projectDir, name)
+    }
 
     if (includes.some(item => item.includes('docs'))) {
       cpSync(resolve(projectDir, 'docs'), projectDir, { recursive: true })

--- a/src/lib/prepare.spec.ts
+++ b/src/lib/prepare.spec.ts
@@ -23,6 +23,7 @@ import {
 } from './prepare.js'
 import type { EnhancedRepository } from './fetch.js'
 import type { getInfos } from './git.js'
+import { getVitepressConfig } from './vitepress.js'
 
 vi.mock('node:fs')
 vi.mock('node:fs/promises')
@@ -862,6 +863,41 @@ describe('prepareDoc', () => {
       '/tmp/docpress/mock/docs/forks.md',
       expect.any(String),
     )
+  })
+
+  it('should default vitepressConfig.lastUpdated to true when the lastUpdated option is enabled', async () => {
+    await prepareDoc({
+      username: 'test-user',
+      lastUpdated: true,
+    })
+
+    expect(getVitepressConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ lastUpdated: true }),
+    )
+  })
+
+  it('should not override an explicit vitepressConfig.lastUpdated value', async () => {
+    await prepareDoc({
+      username: 'test-user',
+      lastUpdated: true,
+      vitepressConfig: { lastUpdated: false } as any,
+    })
+
+    expect(getVitepressConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ lastUpdated: false }),
+    )
+  })
+
+  it('should leave vitepressConfig untouched when the lastUpdated option is disabled', async () => {
+    await prepareDoc({
+      username: 'test-user',
+    })
+
+    expect(getVitepressConfig).toHaveBeenCalledWith(expect.anything(), expect.anything(), undefined)
   })
 
   it('should handle extra header pages', async () => {

--- a/src/lib/prepare.spec.ts
+++ b/src/lib/prepare.spec.ts
@@ -36,6 +36,7 @@ vi.mock('../utils/functions.js', async importOriginal => ({
   getUserRepos: vi.fn(),
   replaceRelativePath: vi.fn(),
   replaceReadmePath: vi.fn(),
+  replaceInternalMdLinks: vi.fn(),
 }))
 vi.mock('../utils/const.js', () => ({
   DOCS_DIR: '/tmp/docpress/mock/docs',

--- a/src/lib/prepare.ts
+++ b/src/lib/prepare.ts
@@ -6,7 +6,7 @@ import type { defineConfig } from 'vitepress'
 import type { PrepareOpts } from '../schemas/prepare.js'
 import { generateFile } from '../utils/templates.js'
 import type { GlobalOpts } from '../schemas/global.js'
-import { createDir, extractFiles, getMdFiles, getUserInfos, getUserRepos, isFile, prettify, replaceReadmePath, replaceRelativePath } from '../utils/functions.js'
+import { createDir, extractFiles, getMdFiles, getUserInfos, getUserRepos, isFile, prettify, replaceInternalMdLinks, replaceReadmePath, replaceRelativePath } from '../utils/functions.js'
 import { DOCPRESS_DIR, DOCS_DIR, FORKS_FILE, INDEX_FILE, TEMPLATE_THEME, VITEPRESS_CONFIG, VITEPRESS_THEME, VITEPRESS_USER_THEME } from '../utils/const.js'
 import { log } from '../utils/logger.js'
 import type { EnhancedRepository } from './fetch.js'
@@ -364,6 +364,9 @@ export function transformDoc(repositories: EnhancedRepository[], user: ReturnTyp
       if (basename(file).toLowerCase() === 'readme.md') {
         replaceReadmePath(file, repository.docpress.replace_url)
       }
+      // Runs last so remaining relative links are rewritten to match the
+      // renamed files (index prefix stripped, lowercased, readme -> introduction)
+      replaceInternalMdLinks(file)
     })
 
     log(`   Generate sidebar for repository '${repository.name}'.`, 'info')

--- a/src/lib/prepare.ts
+++ b/src/lib/prepare.ts
@@ -63,12 +63,13 @@ export interface Index {
  * @param options.vitepressConfig - Path to the VitePress configuration file
  * @param options.forks - Flag to include forked repositories
  * @param options.gitProvider - Git provider used to retrieve data
+ * @param options.lastUpdated - Flag to display each page's last Git commit date, computed by the fetch step
  * @param options.token - Git provider token for API access
  * @param options.username - Git provider username to fetch repositories for
  * @param options.websiteTitle - Custom title for the documentation website
  * @param options.websiteTagline - Custom tagline for the documentation website
  */
-export async function prepareDoc({ extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, token, username, websiteTitle, websiteTagline }: Omit<PrepareOpts, 'usernames' | 'branch' | 'reposFilter'> & { username: PrepareOpts['usernames'][number] }) {
+export async function prepareDoc({ extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, lastUpdated, token, username, websiteTitle, websiteTagline }: Omit<PrepareOpts, 'usernames' | 'branch' | 'reposFilter'> & { username: PrepareOpts['usernames'][number] }) {
   // The forks page relies on matching contributors by login, which the GitLab API does not expose
   const forksEnabled = forks && gitProvider !== 'gitlab'
   if (forks && !forksEnabled) {
@@ -135,7 +136,10 @@ export async function prepareDoc({ extraHeaderPages, extraPublicContent, extraTh
     nav.push({ text: 'Forks', link: '/forks' })
   }
 
-  const config = getVitepressConfig(finalSB, nav, vitepressConfig)
+  // Vitepress only renders the last updated date once its own "lastUpdated" flag is on;
+  // default it to true when the docpress equivalent is enabled, without overriding an explicit user choice
+  const finalVitepressConfig = lastUpdated ? { lastUpdated: true, ...vitepressConfig } : vitepressConfig
+  const config = getVitepressConfig(finalSB, nav, finalVitepressConfig)
 
   generateVitepressFiles(config, finalIndex)
 }

--- a/src/schemas/global.ts
+++ b/src/schemas/global.ts
@@ -39,6 +39,9 @@ export const configSchema = z.object({
   forks: z.boolean()
     .default(false)
     .describe('Whether or not to create the dedicated fork page that aggregate external contributions.'),
+  lastUpdated: z.boolean()
+    .default(false)
+    .describe('Whether or not to inject each page\'s last Git commit date as Vitepress "lastUpdated" frontmatter.'),
   vitepressConfig: z.any()
     .optional()
     .describe('Path to the vitepress configuration file.'),
@@ -67,6 +70,9 @@ export const cliSchema = configSchema
     forks: z.boolean()
       .optional()
       .describe(configSchema.shape.forks.description || ''),
+    lastUpdated: z.boolean()
+      .optional()
+      .describe(configSchema.shape.lastUpdated.description || ''),
     config: z.string()
       .optional()
       .describe('Path to the docpress configuration file.'),
@@ -169,6 +175,7 @@ export const globalOptsSchema = cliSchema
         branch: 'main',
         gitProvider: 'github',
         forks: false,
+        lastUpdated: false,
         ...configData,
         ...rest,
         ...(vitepressConfig

--- a/src/schemas/schemas.spec.ts
+++ b/src/schemas/schemas.spec.ts
@@ -10,6 +10,7 @@ const defaultConfig = {
   token: undefined,
   gitProvider: 'github',
   forks: false,
+  lastUpdated: false,
 }
 
 describe('globalOptsSchema', () => {
@@ -235,6 +236,7 @@ describe('configSchema', () => {
       branch: 'main',
       gitProvider: 'github',
       forks: false,
+      lastUpdated: false,
       token: 'your_token',
       usernames: ['your_username'],
       reposFilter: ['repo1', 'repo2'],

--- a/src/utils/commands.spec.ts
+++ b/src/utils/commands.spec.ts
@@ -28,6 +28,7 @@ describe('parseOptions', () => {
       branch: 'main',
       gitProvider: 'github',
       forks: false,
+      lastUpdated: false,
       reposFilter: ['repo1', 'repo2'],
       token: 'token123',
       usernames: ['user1'],

--- a/src/utils/functions.spec.ts
+++ b/src/utils/functions.spec.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { rimrafSync } from 'rimraf'
-import { checkHttpStatus, createDir, deepMerge, extractFiles, getMdFiles, getUserInfos, getUserRepos, isDir, isFile, isObject, loadConfigFile, prettify, prettifyEnum, splitByComma } from './functions.js'
+import { addLastUpdatedFrontmatter, checkHttpStatus, createDir, deepMerge, extractFiles, getMdFiles, getUserInfos, getUserRepos, isDir, isFile, isObject, loadConfigFile, prettify, prettifyEnum, splitByComma } from './functions.js'
 
 vi.mock('fs')
 vi.mock('rimraf')
@@ -271,6 +271,22 @@ describe('extractFiles', () => {
       '/path/to/dir/03-file3.md',
     ])
   })
+
+  it('should skip a top-level .git directory during traversal', () => {
+    vi.mocked(statSync).mockImplementation(path => ({
+      isFile: () => (path as string).endsWith('.md'),
+      isDirectory: () => !(path as string).endsWith('.md'),
+    } as unknown as ReturnType<typeof statSync>))
+
+    vi.mocked(readdirSync).mockImplementation((path) => {
+      if (path === '/path/to/dir') return ['readme.md', '.git'] as any
+      if (path === '/path/to/dir/.git') return ['HEAD', 'objects'] as any
+      return []
+    })
+
+    const result = extractFiles('/path/to/dir')
+    expect(result).toEqual(['/path/to/dir/readme.md'])
+  })
 })
 
 describe('getMdFiles', () => {
@@ -517,5 +533,46 @@ describe('splitByComma', () => {
 
   it('should handle multiple consecutive commas by returning empty elements', () => {
     expect(splitByComma('a,,b,,c')).toEqual(['a', '', 'b', '', 'c'])
+  })
+})
+
+describe('addLastUpdatedFrontmatter', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should prepend a new frontmatter block when none exists', () => {
+    vi.mocked(readFileSync).mockReturnValue('# Title\n\nContent' as any)
+
+    addLastUpdatedFrontmatter('/path/to/file.md', '2024-05-01T12:00:00+00:00')
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      '/path/to/file.md',
+      '---\nlastUpdated: 2024-05-01T12:00:00+00:00\n---\n\n# Title\n\nContent',
+      'utf8',
+    )
+  })
+
+  it('should merge into existing frontmatter without dropping other fields', () => {
+    vi.mocked(readFileSync).mockReturnValue('---\ntitle: Hello\n---\n# Title\n\nContent' as any)
+
+    addLastUpdatedFrontmatter('/path/to/file.md', '2024-05-01T12:00:00+00:00')
+
+    const [filePath, content, encoding] = vi.mocked(writeFileSync).mock.calls[0]
+    expect(filePath).toBe('/path/to/file.md')
+    expect(encoding).toBe('utf8')
+    expect(content).toContain('title: Hello')
+    expect(content).toContain('lastUpdated: 2024-05-01T12:00:00+00:00')
+    expect(content).toContain('# Title\n\nContent')
+  })
+
+  it('should overwrite an existing lastUpdated value', () => {
+    vi.mocked(readFileSync).mockReturnValue('---\nlastUpdated: 2020-01-01T00:00:00+00:00\n---\nContent' as any)
+
+    addLastUpdatedFrontmatter('/path/to/file.md', '2024-05-01T12:00:00+00:00')
+
+    const content = vi.mocked(writeFileSync).mock.calls[0][1] as string
+    expect(content).toContain('lastUpdated: 2024-05-01T12:00:00+00:00')
+    expect(content).not.toContain('2020-01-01T00:00:00+00:00')
   })
 })

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,11 +1,12 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import { rimrafSync } from 'rimraf'
+import YAML from 'yaml'
 import type { GlobalOpts } from '../schemas/global.js'
 import type { EnhancedRepository } from '../lib/fetch.js'
 import type { getInfos } from '../lib/git.js'
 import { DOCPRESS_DIR } from './const.js'
-import { readmeDocsPathRegex, readmePathRegex, relativePathRegex, removeIdxRegex } from './regex.js'
+import { frontmatterRegex, readmeDocsPathRegex, readmePathRegex, relativePathRegex, removeIdxRegex } from './regex.js'
 
 /**
  * Checks the HTTP status code of a URL
@@ -138,7 +139,7 @@ export function extractFiles(paths: string[] | string): string[] {
       return [path]
     }
     if (isDir(path)) {
-      return readdirSync(path).sort().flatMap(file => extractFiles(join(path, file)))
+      return readdirSync(path).filter(file => file !== '.git').sort().flatMap(file => extractFiles(join(path, file)))
     }
     return []
   })
@@ -275,6 +276,26 @@ export function replaceRelativePath(file: string, url: string) {
     return `[${p1}](${url}/${p2})`
   })
   writeFileSync(file, updatedContent, 'utf8')
+}
+
+/**
+ * Adds or updates the "lastUpdated" frontmatter field of a markdown file, preserving
+ * any frontmatter already present
+ *
+ * @param file - Path to the markdown file to update
+ * @param date - Datetime to set as the "lastUpdated" value
+ */
+export function addLastUpdatedFrontmatter(file: string, date: string) {
+  const content = readFileSync(file, 'utf8')
+  const match = content.match(frontmatterRegex)
+
+  if (match) {
+    const data = YAML.parse(match[1]) ?? {}
+    data.lastUpdated = date
+    writeFileSync(file, content.replace(frontmatterRegex, `---\n${YAML.stringify(data)}---\n`), 'utf8')
+  } else {
+    writeFileSync(file, `---\nlastUpdated: ${date}\n---\n\n${content}`, 'utf8')
+  }
 }
 
 /**

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -6,7 +6,7 @@ import type { GlobalOpts } from '../schemas/global.js'
 import type { EnhancedRepository } from '../lib/fetch.js'
 import type { getInfos } from '../lib/git.js'
 import { DOCPRESS_DIR } from './const.js'
-import { frontmatterRegex, readmeDocsPathRegex, readmePathRegex, relativePathRegex, removeIdxRegex } from './regex.js'
+import { frontmatterRegex, internalMdLinkRegex, readmeDocsPathRegex, readmePathRegex, relativePathRegex, removeIdxRegex } from './regex.js'
 
 /**
  * Checks the HTTP status code of a URL
@@ -296,6 +296,26 @@ export function addLastUpdatedFrontmatter(file: string, date: string) {
   } else {
     writeFileSync(file, `---\nlastUpdated: ${date}\n---\n\n${content}`, 'utf8')
   }
+}
+
+/**
+ * Rewrites relative markdown links to match the renamed target files
+ * Files are renamed during sidebar generation (index prefix stripped, name lowercased,
+ * readme becoming introduction), so in-page links must follow the same convention
+ * to avoid pointing to files that no longer exist
+ *
+ * @param file - Path to the markdown file to process
+ */
+export function replaceInternalMdLinks(file: string) {
+  const fileContent = readFileSync(file, 'utf8')
+  const updatedContent = fileContent.replace(internalMdLinkRegex, (_match, text, dir, target, anchor) => {
+    let filename = prettify(target, { mode: 'lowercase', removeIdx: true })
+    if (filename === 'readme.md') {
+      filename = 'introduction.md'
+    }
+    return `[${text}](${dir ?? ''}${filename}${anchor ?? ''})`
+  })
+  writeFileSync(file, updatedContent, 'utf8')
 }
 
 /**

--- a/src/utils/regex.spec.ts
+++ b/src/utils/regex.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { replaceReadmePath, replaceRelativePath } from './functions.js'
+import { replaceInternalMdLinks, replaceReadmePath, replaceRelativePath } from './functions.js'
 
 vi.mock('fs')
 
@@ -33,6 +33,67 @@ describe('file Path Replacements', () => {
       replaceRelativePath(file, url)
 
       expect(readFileSync).toHaveBeenCalledWith(file, 'utf8')
+      expect(writeFileSync).toHaveBeenCalledWith(file, content, 'utf8')
+    })
+  })
+
+  describe('replaceInternalMdLinks', () => {
+    it('should strip index prefixes and lowercase linked markdown filenames', () => {
+      const file = 'installation.md'
+      const content = 'See the [category](04-profiles.md#devops-profile) and [Guide](./05-SHELL.md).'
+
+      ;(readFileSync as any).mockReturnValue(content)
+
+      replaceInternalMdLinks(file)
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        file,
+        'See the [category](profiles.md#devops-profile) and [Guide](./shell.md).',
+        'utf8',
+      )
+    })
+
+    it('should rewrite readme links to introduction', () => {
+      const file = 'installation.md'
+      const content = 'Back to [home](01-readme.md).'
+
+      ;(readFileSync as any).mockReturnValue(content)
+
+      replaceInternalMdLinks(file)
+
+      expect(writeFileSync).toHaveBeenCalledWith(file, 'Back to [home](introduction.md).', 'utf8')
+    })
+
+    it('should preserve directory prefixes and only rename the file part', () => {
+      const file = 'installation.md'
+      const content = '[Nested](sub/dir/02-page.md#anchor)'
+
+      ;(readFileSync as any).mockReturnValue(content)
+
+      replaceInternalMdLinks(file)
+
+      expect(writeFileSync).toHaveBeenCalledWith(file, '[Nested](sub/dir/page.md#anchor)', 'utf8')
+    })
+
+    it('should not modify external, absolute or anchor links', () => {
+      const file = 'installation.md'
+      const content = '[Ext](https://example.com/01-page.md) [Abs](/01-page.md) [Anchor](#section) [Mail](mailto:a@b.c)'
+
+      ;(readFileSync as any).mockReturnValue(content)
+
+      replaceInternalMdLinks(file)
+
+      expect(writeFileSync).toHaveBeenCalledWith(file, content, 'utf8')
+    })
+
+    it('should not modify links to non-markdown files', () => {
+      const file = 'installation.md'
+      const content = '[Script](scripts/01-setup.sh) ![Image](./assets/01-diagram.png)'
+
+      ;(readFileSync as any).mockReturnValue(content)
+
+      replaceInternalMdLinks(file)
+
       expect(writeFileSync).toHaveBeenCalledWith(file, content, 'utf8')
     })
   })

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -2,3 +2,4 @@ export const relativePathRegex = /\[([^\]]+)\]\(\.\.\/([^)]+)\)/g
 export const readmePathRegex = /\[([^\]]+)\]\((?!\.?\/docs\/|docs\/|http|#)(\.\/)?([^/][^)]+)\)/g
 export const readmeDocsPathRegex = /\[([^\]]+)\]\((\.?\/docs\/|docs\/)([^)]*)\)/g
 export const removeIdxRegex = /^\d{2}-/
+export const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -3,3 +3,4 @@ export const readmePathRegex = /\[([^\]]+)\]\((?!\.?\/docs\/|docs\/|http|#)(\.\/
 export const readmeDocsPathRegex = /\[([^\]]+)\]\((\.?\/docs\/|docs\/)([^)]*)\)/g
 export const removeIdxRegex = /^\d{2}-/
 export const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/
+export const internalMdLinkRegex = /\[([^\]]+)\]\((?!https?:|\/|#|mailto:)([^)#]*\/)?([^)#/]+\.md)(#[^)]*)?\)/g


### PR DESCRIPTION
## Description

Two independent changes bundled in this branch:

### feat: vitepress `lastUpdated` support

New opt-in `lastUpdated` option (config file key or `-l, --last-updated` CLI flag).

Vitepress' native [lastUpdated](https://vitepress.dev/reference/default-theme-last-updated) feature relies on the source files living in a git working tree, which is incompatible with the docpress pipeline (per-repo `.git` folders are removed after cloning, and the aggregated output is not a git repository). Instead, docpress now reads each markdown file's last commit date from the local clone history **before** the `.git` folder is removed, and injects it as `lastUpdated` frontmatter — which vitepress displays in place of the git-based timestamp.

- No Git provider API call involved → no rate limit spent, whatever the number of repositories or files.
- Works identically for GitHub and GitLab sources (plain local git).
- When enabled, the generated vitepress config defaults `lastUpdated: true` (required by the theme to render the date), without overriding an explicit user choice.
- `.git` directories are now skipped during file traversal.

### fix: internal doc links broken by file renaming

Doc files are renamed during sidebar generation (index prefix stripped, name lowercased, `readme.md` → `introduction.md`), but relative links pointing at those files were left untouched, producing dead links at vitepress build time. This broke the `docs` website build ([failing run](https://github.com/this-is-tobi/docs/actions/runs/29382150679/job/87247912544)): `dotfiles/installation.md` links `04-profiles.md#devops-profile`, whose target had been renamed to `profiles.md`.

Relative markdown links are now rewritten with the same renaming rules, preserving directory prefixes and anchors. External (`http(s)`, `mailto:`), absolute, anchor-only and non-markdown links are untouched.

## Checks

- [x] 252 tests passing (25 new)
- [x] Lint & typecheck clean
- [x] End-to-end verified: full `docs` production config (12 repos + forks page + extras) builds successfully with both changes, and the previously dead links are rewritten correctly
