### PR TITLE
fix(ci): publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,8 +41,8 @@ jobs:
       RUNTIME_VERSION: ${{ needs.expose-vars.outputs.BUN_VERSION }}
       PACKAGE_MANAGER: bun
       BUILD_COMMAND: bun run build
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # No NPM_TOKEN: publishing relies on the npmjs.com trusted publisher (OIDC)
+    # registered for this repository and workflow file, via id-token: write
 
   docker:
     uses: this-is-tobi/github-workflows/.github/workflows/build-docker.yml@v0


### PR DESCRIPTION
## Description

npm publish has been failing in CI for every recent release: the `NPM_TOKEN` secret (dating from 2025-08-31) is no longer valid — npm revoked classic tokens and capped granular tokens at 90 days, and the registry masks the rejection as a 404 for scoped packages. This is why the 0.9.x versions had to be published manually and why 0.10.0 never reached the registry ([failing run](https://github.com/this-is-tobi/docpress/actions/runs/29383751775/job/87252683938)).

This drops the token from the `npm` job in favor of the npmjs.com **trusted publisher (OIDC)** registered for this repository and workflow file — `id-token: write` is already granted. The `release-npm` reusable workflow handles the bun case by publishing through the npm CLI, which mints the short-lived OIDC token automatically (see [this-is-tobi/github-workflows#30](https://github.com/this-is-tobi/github-workflows/pull/30)).

As a `fix:` release, merging this also re-triggers the full publish chain, shipping the content of 0.10.0 (`lastUpdated` option + internal dead-link fix, currently unpublished) as **0.10.1** — which unblocks the `docs` website build.

## Merge order

1. Merge [github-workflows#30](https://github.com/this-is-tobi/github-workflows/pull/30) **and its release PR** so the `v0` tag includes the OIDC fallback.
2. On npmjs.com, add a trusted publisher for `@tobi-or-not/docpress`: GitHub Actions / owner `this-is-tobi` / repo `docpress` / workflow `cd.yml` (no environment).
3. Delete the dead `NPM_TOKEN` repo secret.
4. Merge this PR, then its release PR → CD publishes 0.10.1 via OIDC.
