### PR TITLE
fix(cli): improve logging discoverability, error handling, and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Options:
                                        (default: "github")
   -h, --help                           display help for command
   -l, --last-updated                   Whether or not to inject each page's last Git commit date as Vitepress "lastUpdated" frontmatter.
+  --log-level <string>                 Verbosity of the CLI output. Values should be "error", "warn", "info", "trace" or "debug". Defaults to "info", or to the LOG_LEVEL environment variable when set.
   -p, --extra-header-pages <string>    List of comma separated additional files or directories to process Vitepress header pages.
   -r, --repos-filter <string>          List of comma separated repositories to retrieve from Git provider. Default to all user's public repositories.
   -t, --extra-theme <string>           List of comma separated additional files or directories to use as Vitepress theme.

--- a/docs/03-advanced-usage.md
+++ b/docs/03-advanced-usage.md
@@ -17,6 +17,7 @@ Options:
                                        (default: "github")
   -h, --help                           display help for command
   -l, --last-updated                   Whether or not to inject each page's last Git commit date as Vitepress "lastUpdated" frontmatter.
+  --log-level <string>                 Verbosity of the CLI output. Values should be "error", "warn", "info", "trace" or "debug". Defaults to "info", or to the LOG_LEVEL environment variable when set.
   -p, --extra-header-pages <string>    List of comma separated additional files or directories to process Vitepress header pages.
   -r, --repos-filter <string>          List of comma separated repositories to retrieve from Git provider. Default to all user's public repositories.
   -t, --extra-theme <string>           List of comma separated additional files or directories to use as Vitepress theme.
@@ -209,6 +210,7 @@ If this option is used together with an extra theme (`-t` / `--extra-theme`), yo
 Docpress can be configured with an external JSON configuration file specified by the `-C` or `--config` option. This file allows you to set Docpress parameters to automate and customize the documentation fetching and generation process. Key options that can be configured include:
 
 - `usernames`: List of comma separated Git provider usernames used to collect data (equivalent to the `-U` CLI option).
+- `logLevel`: Verbosity of the CLI output, one of `error`, `warn`, `info`, `trace` or `debug` (equivalent to `--log-level`).
 - `reposFilter`: List of repositories to include or exclude (equivalent to the `-r` CLI option).
 - `branch`: Branch from which documentation will be fetched (equivalent to `-b`). When omitted, each repository's own default branch is used, so repositories on `master`, `develop`, etc. are handled correctly.
 - `gitProvider`: Git provider used to retrieve data, `github` or `gitlab` (equivalent to `-g`).
@@ -272,6 +274,22 @@ When collecting from **multiple users**, generated pages are namespaced by usern
 ## Git Provider Selection
 
 The `-g` or `--git-provider` option selects the platform used to collect data. Docpress supports `github` (default) and `gitlab` (gitlab.com). With `gitlab`, the given names can be usernames or group paths, and the fetched repositories are the public projects of that user or group.
+
+## Log Level Selection
+
+The `--log-level` option (or the `logLevel` config key) controls how much detail Docpress prints while it runs. Accepted values are `error`, `warn`, `info` (default), `trace` and `debug` — each level includes all the ones before it, so `debug` prints everything and `error` prints only failures.
+
+```sh
+npx @tobi-or-not/docpress -U <username> --log-level debug
+```
+
+Under the hood, each value maps to a numeric `LOG_LEVEL` environment variable (`error` = `10`, `warn` = `20`, `info` = `30`, `trace` = `40`, `debug` = `50`). Setting `LOG_LEVEL` directly still works and can be more convenient in environments where passing CLI flags is inconvenient (e.g. Docker or CI):
+
+```sh
+LOG_LEVEL=50 npx @tobi-or-not/docpress -U <username>
+```
+
+`--log-level` (or `logLevel` in the config file) takes precedence over the `LOG_LEVEL` environment variable when both are set.
 
 ## Git Provider Token Option
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:docker": "docker build --tag tobi-or-not/docpress --target prod .",
     "build:types": "tsc",
     "build:vite": "vite build",
-    "dev": "bun ./dev/docpress.ts",
+    "dev": "NODE_ENV=development bun ./dev/docpress.ts",
     "dev:clean": "node -e \"require('node:fs').rmSync('./docpress',{recursive:true,force:true})\" && bun run dev",
     "format": "eslint . --fix",
     "lint": "eslint .",

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -32,7 +32,8 @@ vi.mock('./utils/commands.js', () => ({
   explicitOptions: vi.fn((_cmd, opts) => opts),
 }))
 
-vi.mock('./utils/logger.js', () => ({
+vi.mock('./utils/logger.js', async importOriginal => ({
+  ...(await importOriginal()),
   log: vi.fn(),
 }))
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { prepareCmd, main as prepareFn, prepareOpts } from './commands/prepare.j
 import { addOptions, explicitOptions, parseOptions } from './utils/commands.js'
 import { globalOpts } from './commands/global.js'
 import { log } from './utils/logger.js'
+import { formatError } from './utils/functions.js'
 
 /**
  * Creates and configures the Command Line Interface for DocPress
@@ -46,7 +47,7 @@ export function getProgram() {
 export function main() {
   const pm = getProgram()
   pm.parseAsync(process.argv).catch((error) => {
-    log(`\n${error instanceof Error ? error.message : String(error)}`, 'error')
+    log(`\n${formatError(error)}`, 'error')
     process.exit(1)
   })
 }

--- a/src/commands/build.spec.ts
+++ b/src/commands/build.spec.ts
@@ -13,7 +13,8 @@ vi.mock('vitepress', () => ({
 vi.mock('vitepress-plugin-mermaid', () => ({
   withMermaid: vi.fn(),
 }))
-vi.mock('../utils/logger.js', () => ({
+vi.mock('../utils/logger.js', async importOriginal => ({
+  ...(await importOriginal()),
   log: vi.fn(),
 }))
 vi.mock('./global.js', () => ({
@@ -76,8 +77,8 @@ describe('suppressVueWarnings', () => {
 
     await suppressVueWarnings(mockCallback)
 
-    expect(console.warn).toHaveBeenCalledWith('Regular warning')
-    expect(console.warn).not.toHaveBeenCalledWith('[Vue warn]: Invalid watch source: something')
+    expect(log).toHaveBeenCalledWith('Regular warning', 'warn')
+    expect(log).not.toHaveBeenCalledWith('[Vue warn]: Invalid watch source: something', 'warn')
   })
 
   it('should suppress Vue warnings about open:false', async () => {
@@ -89,8 +90,8 @@ describe('suppressVueWarnings', () => {
 
     await suppressVueWarnings(mockCallback)
 
-    expect(console.warn).toHaveBeenCalledWith('Regular warning')
-    expect(console.warn).not.toHaveBeenCalledWith('[Vue warn]: Something with { open: false }')
+    expect(log).toHaveBeenCalledWith('Regular warning', 'warn')
+    expect(log).not.toHaveBeenCalledWith('[Vue warn]: Something with { open: false }', 'warn')
   })
 
   it('should restore console.warn even if callback throws', async () => {
@@ -120,7 +121,7 @@ describe('main', () => {
     expect(vitepressBuild).toHaveBeenCalledWith(DOCPRESS_DIR, expect.objectContaining({
       onAfterConfigResolve: expect.any(Function),
     }))
-    expect(log).toHaveBeenCalledWith(`\n\nDocpress build succeeded.`, 'success')
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/^\n\nDocpress build succeeded in .+\.$/), 'success')
   })
 
   it('should apply withMermaid via onAfterConfigResolve', async () => {
@@ -133,19 +134,20 @@ describe('main', () => {
     expect(withMermaid).toHaveBeenCalledWith({ markdown: {}, vite: {} })
   })
 
-  it('should log start and error messages when build fails', async () => {
+  it('should throw a contextualized error instead of logging/exiting itself', async () => {
     const error = new Error('Build failed')
     ;(vitepressBuild as any).mockRejectedValueOnce(error) // Simulate failed build
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
 
-    await main()
+    await expect(main()).rejects.toThrow('Docpress build failed: Build failed')
 
     expect(log).toHaveBeenCalledWith(`\n-> Start building Vitepress website.\n\n`, 'info')
     expect(vitepressBuild).toHaveBeenCalledWith(DOCPRESS_DIR, expect.objectContaining({
       onAfterConfigResolve: expect.any(Function),
     }))
-    expect(log).toHaveBeenCalledWith(`\n\nDocpress build failed : ${error}`, 'error')
-    expect(exitSpy).toHaveBeenCalledWith(1)
+    // Reporting and exiting are cli.ts's job now, not build.ts's
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining('failed'), 'error')
+    expect(exitSpy).not.toHaveBeenCalled()
     exitSpy.mockRestore()
   })
 })

--- a/src/commands/build.spec.ts
+++ b/src/commands/build.spec.ts
@@ -50,7 +50,7 @@ describe('buildCmd', () => {
 describe('suppressVueWarnings', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Save original console.warn
+    // Stand in for the real console.warn so we can assert what gets forwarded
     vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -69,6 +69,7 @@ describe('suppressVueWarnings', () => {
   })
 
   it('should suppress Vue warnings about invalid watch source', async () => {
+    const warnSpy = vi.mocked(console.warn)
     const mockCallback = async () => {
       console.warn('[Vue warn]: Invalid watch source: something')
       console.warn('Regular warning')
@@ -77,11 +78,13 @@ describe('suppressVueWarnings', () => {
 
     await suppressVueWarnings(mockCallback)
 
-    expect(log).toHaveBeenCalledWith('Regular warning', 'warn')
-    expect(log).not.toHaveBeenCalledWith('[Vue warn]: Invalid watch source: something', 'warn')
+    // The regular warning is forwarded to the real console.warn, the targeted one is dropped
+    expect(warnSpy).toHaveBeenCalledWith('Regular warning')
+    expect(warnSpy).not.toHaveBeenCalledWith('[Vue warn]: Invalid watch source: something')
   })
 
   it('should suppress Vue warnings about open:false', async () => {
+    const warnSpy = vi.mocked(console.warn)
     const mockCallback = async () => {
       console.warn('[Vue warn]: Something with { open: false }')
       console.warn('Regular warning')
@@ -90,8 +93,29 @@ describe('suppressVueWarnings', () => {
 
     await suppressVueWarnings(mockCallback)
 
-    expect(log).toHaveBeenCalledWith('Regular warning', 'warn')
-    expect(log).not.toHaveBeenCalledWith('[Vue warn]: Something with { open: false }', 'warn')
+    expect(warnSpy).toHaveBeenCalledWith('Regular warning')
+    expect(warnSpy).not.toHaveBeenCalledWith('[Vue warn]: Something with { open: false }')
+  })
+
+  it('should forward non-suppressed warnings without recursing when the logger writes via console.warn', async () => {
+    const warnSpy = vi.mocked(console.warn)
+    const chunkWarning = '(!) Some chunks are larger than 500 kB after minification'
+    // The real logger writes warnings through console.warn - the very function this
+    // helper overrides. Forwarding a warning back through log() would recurse until
+    // the stack overflows and aborts the Vitepress build, so this guards against it.
+    vi.mocked(log).mockImplementation((msg: string) => { console.warn(msg) })
+
+    try {
+      const callback = async () => {
+        console.warn(chunkWarning)
+        return 'ok'
+      }
+
+      await expect(suppressVueWarnings(callback)).resolves.toBe('ok')
+      expect(warnSpy).toHaveBeenCalledWith(chunkWarning)
+    } finally {
+      vi.mocked(log).mockReset()
+    }
   })
 
   it('should restore console.warn even if callback throws', async () => {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -18,8 +18,14 @@ export async function suppressVueWarnings<T>(callback: () => Promise<T>): Promis
   // Store the original console.warn
   const originalWarn = console.warn
 
-  // Override console.warn to suppress specific Vue warnings, routing the rest
-  // through the shared logger so LOG_LEVEL gating and coloring stay consistent
+  // Override console.warn to suppress two specific, noisy Vue/Vitepress warnings
+  // and forward everything else, untouched, to the real console.warn.
+  //
+  // These must NOT be routed through log(): log() writes via console.warn, which
+  // is this very override, so forwarding a non-suppressed warning through it would
+  // recurse until the stack overflows and aborts the whole Vitepress build. Vite's
+  // "chunks are larger than 500 kB" warning is exactly such a case, which is why
+  // the build failed with "[vite:reporter] Maximum call stack size exceeded".
   console.warn = function (...args) {
     if (
       args.length > 0
@@ -30,7 +36,8 @@ export async function suppressVueWarnings<T>(callback: () => Promise<T>): Promis
       // Skip this warning
       return
     }
-    log(args.map(String).join(' '), 'warn')
+    // Pass other warnings straight to the original console.warn
+    originalWarn.apply(console, args)
   }
 
   try {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -5,6 +5,7 @@ import { createCommand } from 'commander'
 import { addOptions } from '../utils/commands.js'
 import { DOCPRESS_DIR } from '../utils/const.js'
 import { log } from '../utils/logger.js'
+import { formatDuration, formatError } from '../utils/functions.js'
 import { globalOpts } from './global.js'
 
 /**
@@ -17,7 +18,8 @@ export async function suppressVueWarnings<T>(callback: () => Promise<T>): Promis
   // Store the original console.warn
   const originalWarn = console.warn
 
-  // Override console.warn to suppress specific Vue warnings
+  // Override console.warn to suppress specific Vue warnings, routing the rest
+  // through the shared logger so LOG_LEVEL gating and coloring stay consistent
   console.warn = function (...args) {
     if (
       args.length > 0
@@ -28,8 +30,7 @@ export async function suppressVueWarnings<T>(callback: () => Promise<T>): Promis
       // Skip this warning
       return
     }
-    // Pass other warnings to the original console.warn
-    originalWarn.apply(console, args)
+    log(args.map(String).join(' '), 'warn')
   }
 
   try {
@@ -61,6 +62,7 @@ export const buildCmd = addOptions(createCommand(cmdName), globalOpts)
  */
 export async function main() {
   log(`\n-> Start building Vitepress website.\n\n`, 'info')
+  const start = Date.now()
 
   try {
     // Build VitePress with Vue warnings suppressed
@@ -71,10 +73,11 @@ export async function main() {
         },
       })
     })
-
-    log(`\n\nDocpress build succeeded.`, 'success')
   } catch (error) {
-    log(`\n\nDocpress build failed : ${error}`, 'error')
-    process.exit(1)
+    // Re-thrown (not logged/exited here) so cli.ts's single top-level catch
+    // is the only place that reports a failure and sets the exit code.
+    throw new Error(`Docpress build failed: ${formatError(error)}`)
   }
+
+  log(`\n\nDocpress build succeeded in ${formatDuration(Date.now() - start)}.`, 'success')
 }

--- a/src/commands/fetch.spec.ts
+++ b/src/commands/fetch.spec.ts
@@ -8,9 +8,14 @@ import { globalOpts } from './global.js'
 import { createDir } from '../utils/functions.js'
 
 vi.mock('../lib/fetch.js', () => ({ fetchDoc: vi.fn() }))
-vi.mock('../utils/logger.js', () => ({ log: vi.fn() }))
+vi.mock('../utils/logger.js', async importOriginal => ({
+  ...(await importOriginal()),
+  log: vi.fn(),
+}))
 vi.mock('../utils/functions.js', () => ({
   createDir: vi.fn(),
+  formatDuration: vi.fn(() => '0ms'),
+  formatError: vi.fn(error => (error instanceof Error ? error.message : String(error))),
   prettifyEnum: vi.fn(arr => arr.join('|')),
   splitByComma: vi.fn(str => str.split(',')),
 }))
@@ -165,6 +170,52 @@ describe('main', () => {
 
     expect(vi.mocked(createDir)).toHaveBeenCalledWith(expect.any(String), { clean: true })
     expect(fetchDoc).toHaveBeenCalled()
+  })
+
+  it('should log a success summary once every username succeeds', async () => {
+    const mockOpts = {
+      usernames: ['testUser'],
+      branch: 'main',
+      gitProvider: 'github' as const,
+    }
+
+    await main(mockOpts)
+
+    expect(log).toHaveBeenCalledWith('   Fetched documentation for 1/1 username(s) in 0ms.', 'success')
+  })
+
+  it('should continue with remaining usernames when one fails, and log a warn summary', async () => {
+    const mockOpts = {
+      usernames: ['goodUser', 'badUser'],
+      branch: 'main',
+      gitProvider: 'github' as const,
+    }
+
+    vi.mocked(fetchDoc)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('network error'))
+
+    await main(mockOpts)
+
+    expect(fetchDoc).toHaveBeenCalledTimes(2)
+    expect(log).toHaveBeenCalledWith(`   Failed to fetch documentation for 'badUser': network error`, 'error')
+    expect(log).toHaveBeenCalledWith('   Fetched documentation for 1/2 username(s) in 0ms.', 'warn')
+  })
+
+  it('should throw when every username fails', async () => {
+    const mockOpts = {
+      usernames: ['user1', 'user2'],
+      branch: 'main',
+      gitProvider: 'github' as const,
+    }
+
+    vi.mocked(fetchDoc)
+      .mockRejectedValueOnce(new Error('boom1'))
+      .mockRejectedValueOnce(new Error('boom2'))
+
+    await expect(main(mockOpts)).rejects.toThrow(
+      'Failed to fetch documentation for all requested username(s): user1, user2.',
+    )
   })
 })
 

--- a/src/commands/fetch.ts
+++ b/src/commands/fetch.ts
@@ -1,5 +1,5 @@
 import { createCommand, createOption } from 'commander'
-import { createDir } from '../utils/functions.js'
+import { createDir, formatDuration, formatError } from '../utils/functions.js'
 import { DOCPRESS_DIR } from '../utils/const.js'
 import { log } from '../utils/logger.js'
 import { addOptions, explicitOptions, parseOptions } from '../utils/commands.js'
@@ -42,6 +42,7 @@ export const fetchCmd = addOptions(createCommand(cmdName), [...fetchOpts, ...glo
 export async function main(opts: FetchOpts) {
   const { usernames, reposFilter, token, branch, gitProvider, lastUpdated } = opts
   log(`\n-> Start fetching documentation files. This may take a moment, especially for larger repositories.`, 'info')
+  const start = Date.now()
 
   createDir(DOCPRESS_DIR, { clean: true })
   const failedUsers: string[] = []
@@ -54,11 +55,14 @@ export async function main(opts: FetchOpts) {
       await fetchDoc({ username, branch, reposFilter: finalRF, gitProvider, token, lastUpdated, multiUser: usernames.length > 1 })
     } catch (error) {
       failedUsers.push(username)
-      log(`   Failed to fetch documentation for '${username}': ${error instanceof Error ? error.message : String(error)}`, 'error')
+      log(`   Failed to fetch documentation for '${username}': ${formatError(error)}`, 'error')
     }
   }
 
   if (failedUsers.length === usernames.length) {
     throw new Error(`Failed to fetch documentation for all requested username(s): ${failedUsers.join(', ')}.`)
   }
+
+  const succeeded = usernames.length - failedUsers.length
+  log(`   Fetched documentation for ${succeeded}/${usernames.length} username(s) in ${formatDuration(Date.now() - start)}.`, failedUsers.length ? 'warn' : 'success')
 }

--- a/src/commands/global.spec.ts
+++ b/src/commands/global.spec.ts
@@ -3,14 +3,15 @@ import { cliSchema } from '../schemas/global.js'
 import { globalOpts } from './global.js'
 
 describe('globalOpts', () => {
-  it('should contain 3 options', () => {
-    expect(globalOpts).toHaveLength(3)
+  it('should contain 4 options', () => {
+    expect(globalOpts).toHaveLength(4)
   })
 
   it('should define the correct option with flags and argument', () => {
     expect(globalOpts[0].flags).toBe('-C, --config <string>')
-    expect(globalOpts[1].flags).toBe('-T, --token <string>')
-    expect(globalOpts[2].flags).toBe('-U, --usernames <string>')
+    expect(globalOpts[1].flags).toBe('--log-level <string>')
+    expect(globalOpts[2].flags).toBe('-T, --token <string>')
+    expect(globalOpts[3].flags).toBe('-U, --usernames <string>')
   })
 
   it('should have the correct description from the schema', () => {

--- a/src/commands/global.ts
+++ b/src/commands/global.ts
@@ -6,6 +6,7 @@ import { cliSchema } from '../schemas/global.js'
  */
 export const globalOpts = [
   createOption('-C, --config <string>', cliSchema.shape.config.description),
+  createOption('--log-level <string>', cliSchema.shape.logLevel.description),
   createOption('-T, --token <string>', cliSchema.shape.token.description),
   createOption('-U, --usernames <string>', cliSchema.shape.usernames.description),
 ]

--- a/src/commands/prepare.spec.ts
+++ b/src/commands/prepare.spec.ts
@@ -26,7 +26,10 @@ vi.mock('../lib/prepare.js', () => ({
   prepareDoc: vi.fn(),
 }))
 vi.mock('../lib/vitepress.js', () => ({ getVitepressConfig: vi.fn() }))
-vi.mock('../utils/logger.js', () => ({ log: vi.fn() }))
+vi.mock('../utils/logger.js', async importOriginal => ({
+  ...(await importOriginal()),
+  log: vi.fn(),
+}))
 vi.spyOn(prepareMod, 'main')
 
 const { prepareCmd, prepareOpts, main } = prepareMod
@@ -126,6 +129,38 @@ describe('main', () => {
   it('should forward the lastUpdated flag to prepareDoc', async () => {
     await main({ ...mockOpts, lastUpdated: true })
     expect(prepareDoc).toHaveBeenCalledWith(expect.objectContaining({ lastUpdated: true }))
+  })
+
+  it('should log a success summary once every username succeeds', async () => {
+    await main(mockOpts)
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/^ {3}Prepared documentation for 1\/1 username\(s\) in .+\.$/),
+      'success',
+    )
+  })
+
+  it('should continue with remaining usernames when one fails, and log a warn summary', async () => {
+    vi.mocked(prepareDoc)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('render error'))
+
+    await main({ ...mockOpts, usernames: ['goodUser', 'badUser'] })
+
+    expect(log).toHaveBeenCalledWith(`   Failed to prepare documentation for 'badUser': render error`, 'error')
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/^ {3}Prepared documentation for 1\/2 username\(s\) in .+\.$/),
+      'warn',
+    )
+  })
+
+  it('should throw when every username fails', async () => {
+    vi.mocked(prepareDoc)
+      .mockRejectedValueOnce(new Error('boom1'))
+      .mockRejectedValueOnce(new Error('boom2'))
+
+    await expect(main({ ...mockOpts, usernames: ['user1', 'user2'] })).rejects.toThrow(
+      'Failed to prepare documentation for all requested username(s): user1, user2.',
+    )
   })
 
   // it('should log the start message and call getUserInfos and getUserRepos', async () => {

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -5,7 +5,7 @@ import { addOptions, explicitOptions, parseOptions } from '../utils/commands.js'
 import { prepareDoc } from '../lib/prepare.js'
 import type { PrepareOpts } from '../schemas/prepare.js'
 import { log } from '../utils/logger.js'
-import { createDir } from '../utils/functions.js'
+import { createDir, formatDuration, formatError } from '../utils/functions.js'
 import { VITEPRESS_CONFIG } from '../utils/const.js'
 import { globalOpts } from './global.js'
 
@@ -45,9 +45,23 @@ export const prepareCmd = addOptions(createCommand(cmdName), [...prepareOpts, ..
 export async function main(opts: PrepareOpts) {
   const { extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, lastUpdated, token, usernames, websiteTitle, websiteTagline } = opts
   log(`\n-> Start transform files to prepare Vitepress build.`, 'info')
+  const start = Date.now()
 
   createDir(dirname(VITEPRESS_CONFIG), { clean: true })
+  const failedUsers: string[] = []
   for (const username of usernames) {
-    await prepareDoc({ extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, lastUpdated, token, username, websiteTitle, websiteTagline })
+    try {
+      await prepareDoc({ extraHeaderPages, extraPublicContent, extraTheme, vitepressConfig, forks, gitProvider, lastUpdated, token, username, websiteTitle, websiteTagline })
+    } catch (error) {
+      failedUsers.push(username)
+      log(`   Failed to prepare documentation for '${username}': ${formatError(error)}`, 'error')
+    }
   }
+
+  if (failedUsers.length === usernames.length) {
+    throw new Error(`Failed to prepare documentation for all requested username(s): ${failedUsers.join(', ')}.`)
+  }
+
+  const succeeded = usernames.length - failedUsers.length
+  log(`   Prepared documentation for ${succeeded}/${usernames.length} username(s) in ${formatDuration(Date.now() - start)}.`, failedUsers.length ? 'warn' : 'success')
 }

--- a/src/lib/fetch.spec.ts
+++ b/src/lib/fetch.spec.ts
@@ -238,7 +238,7 @@ describe('getDoc', () => {
 
     await getDoc()
 
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('No repository respect docpress rules.'))
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('No repositories to process.'))
   })
 
   it('should clone repositories starting with a dot', async () => {
@@ -262,6 +262,62 @@ describe('getDoc', () => {
       repos[0].docpress.includes,
       undefined,
     )
+  })
+
+  it('should log a success summary when every repository clones successfully', async () => {
+    console.info = vi.fn()
+    vi.mocked(cloneRepo).mockResolvedValueOnce(true)
+
+    const repos = [
+      {
+        name: 'repo1',
+        clone_url: 'https://github.com/testUser/repo1',
+        fork: false,
+        private: false,
+        docpress: { projectPath: '/path/to/repo1', branch: 'main', includes: ['README.md'] },
+      },
+    ] as unknown as EnhancedRepository[]
+
+    await getDoc(repos, ['repo1'])
+
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Cloned 1/1 repository(ies).'))
+  })
+
+  it('should log a warn summary listing failed repositories', async () => {
+    console.warn = vi.fn()
+    vi.mocked(cloneRepo).mockResolvedValueOnce(false)
+
+    const repos = [
+      {
+        name: 'repo1',
+        clone_url: 'https://github.com/testUser/repo1',
+        fork: false,
+        private: false,
+        docpress: { projectPath: '/path/to/repo1', branch: 'main', includes: ['README.md'] },
+      },
+    ] as unknown as EnhancedRepository[]
+
+    await getDoc(repos, ['repo1'])
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Cloned 0/1 repository(ies), 1 failed: repo1.'))
+  })
+
+  it('should warn when no repository matches the current filters', async () => {
+    console.warn = vi.fn()
+
+    const repos = [
+      {
+        name: 'repo1',
+        clone_url: 'https://github.com/testUser/repo1',
+        fork: false,
+        private: false,
+        docpress: { projectPath: '/path/to/repo1', branch: 'main', includes: ['README.md'] },
+      },
+    ] as unknown as EnhancedRepository[]
+
+    await getDoc(repos, ['nonexistent-repo'])
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('No repository matched the current filters.'))
   })
 })
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -193,7 +193,7 @@ export async function generateInfos(user: Awaited<ReturnType<typeof getInfos>>['
  */
 export async function getDoc(repos?: EnhancedRepository[], reposFilter?: FetchOpts['reposFilter'], lastUpdated?: boolean) {
   if (!repos) {
-    log(`   No repository respect docpress rules.`, 'warn')
+    log(`   No repositories to process.`, 'warn')
     return
   }
 
@@ -206,9 +206,17 @@ export async function getDoc(repos?: EnhancedRepository[], reposFilter?: FetchOp
       }),
   )
 
+  if (!results.length) {
+    log(`   No repository matched the current filters.`, 'warn')
+    return
+  }
+
   const failed = results.filter(({ success }) => !success).map(({ name }) => name)
+  const succeeded = results.length - failed.length
   if (failed.length) {
-    log(`   ${failed.length} repository(ies) failed to clone: ${failed.join(', ')}.`, 'warn')
+    log(`   Cloned ${succeeded}/${results.length} repository(ies), ${failed.length} failed: ${failed.join(', ')}.`, 'warn')
+  } else {
+    log(`   Cloned ${succeeded}/${results.length} repository(ies).`, 'success')
   }
 }
 

--- a/src/lib/git.spec.ts
+++ b/src/lib/git.spec.ts
@@ -14,7 +14,15 @@ vi.mock('node:path', () => ({
   resolve: vi.fn((...args) => args.join('/')),
   relative: vi.fn((from: string, to: string) => to.replace(`${from}/`, '')),
 }))
-vi.mock('../utils/functions.js')
+vi.mock('../utils/functions.js', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    addLastUpdatedFrontmatter: vi.fn(),
+    createDir: vi.fn(),
+    getMdFiles: vi.fn(),
+  }
+})
 vi.mock('../utils/logger.js')
 
 describe('quietOctokitLog', () => {
@@ -23,21 +31,14 @@ describe('quietOctokitLog', () => {
   })
 
   it('should suppress 404 warnings and errors but forward the rest', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
     quietOctokitLog.warn('boom 404 not found')
     quietOctokitLog.error('boom 404 not found')
-    expect(warnSpy).not.toHaveBeenCalled()
-    expect(errorSpy).not.toHaveBeenCalled()
+    expect(log).not.toHaveBeenCalled()
 
     quietOctokitLog.warn('real warning')
     quietOctokitLog.error('real error')
-    expect(warnSpy).toHaveBeenCalledWith('real warning')
-    expect(errorSpy).toHaveBeenCalledWith('real error')
-
-    warnSpy.mockRestore()
-    errorSpy.mockRestore()
+    expect(log).toHaveBeenCalledWith('real warning', 'warn')
+    expect(log).toHaveBeenCalledWith('real error', 'error')
   })
 })
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -5,7 +5,7 @@ import { simpleGit } from 'simple-git'
 import type { SimpleGit } from 'simple-git'
 import type { GlobalOpts } from '../schemas/global.js'
 import type { FetchOpts } from '../schemas/fetch.js'
-import { addLastUpdatedFrontmatter, createDir, getMdFiles } from '../utils/functions.js'
+import { addLastUpdatedFrontmatter, createDir, formatError, getMdFiles } from '../utils/functions.js'
 import { log } from '../utils/logger.js'
 import type { EnhancedRepository } from './fetch.js'
 
@@ -16,10 +16,10 @@ export const quietOctokitLog = {
   debug: () => {},
   info: () => {},
   warn: (message: string) => {
-    if (!message.includes('404')) console.warn(message)
+    if (!message.includes('404')) log(message, 'warn')
   },
   error: (message: string) => {
-    if (!message.includes('404')) console.error(message)
+    if (!message.includes('404')) log(message, 'error')
   },
 }
 
@@ -72,7 +72,7 @@ export async function getContributors({
   } catch (error) {
     // A deleted / private / rate-limited upstream must not abort the whole
     // prepare step: degrade to "no source" so this single fork is skipped.
-    log(`   Failed to get repository infos for '${repository.name}'. Error : ${error instanceof Error ? error.message : String(error)}`, 'warn')
+    log(`   Failed to get repository infos for '${repository.name}'. Error : ${formatError(error)}`, 'warn')
     return { source: undefined, contributors: [] }
   }
   if (!repo.source?.owner?.login) {
@@ -92,7 +92,7 @@ export async function getContributors({
     }
   } catch (error) {
     log(
-      `   Failed to get contributors infos for repository '${repository.name}'. Error : ${error instanceof Error ? error.message : String(error)}`,
+      `   Failed to get contributors infos for repository '${repository.name}'. Error : ${formatError(error)}`,
       'warn',
     )
     return { source: repo.source, contributors: [] }
@@ -151,7 +151,7 @@ export async function applyLastUpdated(git: SimpleGit, projectDir: string, name:
     const logOutput = await git.raw(['-c', 'core.quotePath=false', 'log', '--format=%cI', '--name-only'])
     dates = parseLastCommitDates(logOutput)
   } catch (error) {
-    log(`   Unable to read commit history for repository '${name}'. Error : ${error instanceof Error ? error.message : String(error)}`, 'warn')
+    log(`   Unable to read commit history for repository '${name}'. Error : ${formatError(error)}`, 'warn')
     return
   }
 
@@ -210,7 +210,7 @@ export async function cloneRepo(name: string, url: string, projectDir: string, b
     rmSync(resolve(projectDir, '.git'), { recursive: true })
     return true
   } catch (error) {
-    log(`   Error when cloning repository '${name}': ${error instanceof Error ? error.message : String(error)}.`, 'error')
+    log(`   Error when cloning repository '${name}': ${formatError(error)}.`, 'error')
     return false
   }
 }

--- a/src/lib/gitlab.spec.ts
+++ b/src/lib/gitlab.spec.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getInfos, GITLAB_API_URL } from './gitlab.js'
 
-vi.mock('../utils/logger.js', () => ({ log: vi.fn() }))
+vi.mock('../utils/logger.js', async importOriginal => ({
+  ...(await importOriginal()),
+  log: vi.fn(),
+}))
 
 const mockGitlabUser = {
   id: 42,

--- a/src/lib/prepare.spec.ts
+++ b/src/lib/prepare.spec.ts
@@ -2,7 +2,7 @@ import { appendFileSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync,
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getMdFiles, getUserInfos, getUserRepos } from '../utils/functions.js'
+import { extractFiles, getMdFiles, getUserInfos, getUserRepos } from '../utils/functions.js'
 import {
   addContent,
   addExtraPages,
@@ -561,6 +561,15 @@ describe('generateVitepressFiles', () => {
       '/tmp/docpress/mock/docs/index.md',
       expect.stringContaining('layout: home'),
     )
+  })
+
+  it('should throw a clear error when no template theme files are found', () => {
+    vi.mocked(extractFiles).mockReturnValueOnce([])
+
+    expect(() => generateVitepressFiles(
+      { title: 'My Project' },
+      { layout: 'home', hero: { name: 'My Projects', tagline: 'Awesome projects' }, features: [] },
+    )).toThrow(/No template theme files found at '\/tmp\/docpress\/mock\/templates\/theme'/)
   })
 })
 

--- a/src/lib/prepare.ts
+++ b/src/lib/prepare.ts
@@ -6,7 +6,7 @@ import type { defineConfig } from 'vitepress'
 import type { PrepareOpts } from '../schemas/prepare.js'
 import { generateFile } from '../utils/templates.js'
 import type { GlobalOpts } from '../schemas/global.js'
-import { createDir, extractFiles, getMdFiles, getUserInfos, getUserRepos, isFile, prettify, replaceInternalMdLinks, replaceReadmePath, replaceRelativePath } from '../utils/functions.js'
+import { createDir, extractFiles, formatError, getMdFiles, getUserInfos, getUserRepos, isFile, prettify, replaceInternalMdLinks, replaceReadmePath, replaceRelativePath } from '../utils/functions.js'
 import { DOCPRESS_DIR, DOCS_DIR, FORKS_FILE, INDEX_FILE, TEMPLATE_THEME, VITEPRESS_CONFIG, VITEPRESS_THEME, VITEPRESS_USER_THEME } from '../utils/const.js'
 import { log } from '../utils/logger.js'
 import type { EnhancedRepository } from './fetch.js'
@@ -512,7 +512,7 @@ export async function parseVitepressConfig(path: string): Promise<Partial<Return
     const { config } = await import(resolve(process.cwd(), path))
     return config ?? {}
   } catch (error) {
-    log(`   Unable to load existing Vitepress config '${path}', starting from an empty config. ${error instanceof Error ? error.message : ''}`, 'warn')
+    log(`   Unable to load existing Vitepress config '${path}', starting from an empty config. ${formatError(error)}`, 'warn')
     return {}
   }
 }

--- a/src/lib/prepare.ts
+++ b/src/lib/prepare.ts
@@ -533,7 +533,7 @@ export async function parseVitepressIndex(path: string): Promise<Index> {
  *
  * @param vitepressConfig - VitePress configuration object
  * @param index - Index page configuration
- * @returns The list of theme files that were generated
+ * @throws Error if no template theme files are found
  */
 export function generateVitepressFiles(vitepressConfig: Partial<ReturnType<typeof defineConfig>>, index: Index) {
   const separator = '---\n'
@@ -543,8 +543,16 @@ export function generateVitepressFiles(vitepressConfig: Partial<ReturnType<typeo
   writeFileSync(VITEPRESS_CONFIG, `export const config = ${JSON.stringify(vitepressConfig, null, 2)}\n\nexport default config\n`)
   log(`   Generate index file.`, 'info')
   writeFileSync(INDEX_FILE, separator + YAML.stringify(index))
+
+  // Fail here (not during the later Vitepress build) so the error points at the
+  // actual missing source instead of surfacing as an opaque Vite ENOENT
+  const themeFiles = extractFiles(TEMPLATE_THEME)
+  if (!themeFiles.length) {
+    throw new Error(`No template theme files found at '${TEMPLATE_THEME}'. The Vitepress build cannot succeed without them.`)
+  }
+
   log(`   Add Docpress theme files.`, 'info')
-  return extractFiles(TEMPLATE_THEME).forEach((path) => {
+  themeFiles.forEach((path) => {
     const relativePath = path.replace(`${TEMPLATE_THEME}/`, '')
     generateFile(path, resolve(VITEPRESS_THEME, relativePath))
   })

--- a/src/schemas/global.ts
+++ b/src/schemas/global.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
-import { loadConfigFile, prettifyEnum, redactToken, splitByComma } from '../utils/functions.js'
-import { log } from '../utils/logger.js'
+import { loadConfigFile, prettifyEnum, splitByComma } from '../utils/functions.js'
+import type { LogLevelName } from '../utils/logger.js'
+import { LOG_LEVEL_NAMES, logLevelValue } from '../utils/logger.js'
 
 /**
  * List of supported Git providers
@@ -22,6 +23,9 @@ export const configSchema = z.object({
   usernames: z.string()
     .array()
     .describe('List of comma separated Git provider usernames used to collect data.'),
+  logLevel: z.enum(LOG_LEVEL_NAMES)
+    .optional()
+    .describe(`Verbosity of the CLI output. Values should be ${prettifyEnum(LOG_LEVEL_NAMES)}. Defaults to "info", or to the LOG_LEVEL environment variable when set.`),
   // Fetch
   branch: z.string()
     .regex(safeRefRegex, safeRefMessage)
@@ -75,6 +79,9 @@ export const cliSchema = configSchema
     gitProvider: z.enum(providers)
       .optional()
       .describe(configSchema.shape.gitProvider.description || ''),
+    logLevel: z.enum(LOG_LEVEL_NAMES)
+      .optional()
+      .describe(configSchema.shape.logLevel.description || ''),
     forks: z.boolean()
       .optional()
       .describe(configSchema.shape.forks.description || ''),
@@ -183,6 +190,21 @@ function resolveToken(token: string | undefined, gitProvider: string | undefined
 }
 
 /**
+ * Applies an explicitly resolved log level (CLI flag > config file) as the
+ * LOG_LEVEL env var consumed by the logger. Left untouched when neither the CLI
+ * flag nor the config file set one, so an existing numeric LOG_LEVEL env var
+ * (or the logger's own default) keeps working exactly as before
+ *
+ * @param logLevel - Log level name explicitly provided via CLI flag or config file
+ */
+function resolveLogLevel(logLevel: LogLevelName | undefined): void {
+  if (logLevel) {
+    // eslint-disable-next-line dot-notation
+    process.env['LOG_LEVEL'] = String(logLevelValue(logLevel))
+  }
+}
+
+/**
  * Schema for global options that combines CLI arguments and configuration files
  * Merges config sources with precedence: CLI options > config file > defaults
  */
@@ -191,8 +213,6 @@ export const globalOptsSchema = cliSchema
   .transform((data, ctx) => {
     try {
       const { config, vitepressConfig, token, ...rest } = data
-
-      log(`Debug: Schema transform input: ${JSON.stringify(redactToken(data))}`, 'debug')
 
       // Load and validate configuration from file
       const configData = validateConfigData(prepareConfigData(loadConfigFile(config)))
@@ -216,7 +236,7 @@ export const globalOptsSchema = cliSchema
           : {}),
       }
 
-      log(`Debug: Final merged config: ${JSON.stringify(mergedConfig)}`, 'debug')
+      resolveLogLevel(mergedConfig.logLevel)
 
       return validateFinalConfig({ ...mergedConfig, token: resolveToken(token, mergedConfig.gitProvider) })
     } catch (error) {

--- a/src/schemas/schemas.spec.ts
+++ b/src/schemas/schemas.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Config, GlobalOpts } from './global.js'
 import { cliSchema, configSchema, globalOptsSchema } from './global.js'
 
@@ -102,6 +102,31 @@ describe('globalOptsSchema', () => {
     })
     expect(result.gitProvider).toBe('github')
     expect(result.branch).toBeUndefined()
+  })
+
+  describe('logLevel resolution', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs()
+    })
+
+    it('should apply an explicit logLevel to the LOG_LEVEL env var', () => {
+      vi.stubEnv('LOG_LEVEL', '10')
+
+      const result = globalOptsSchema.parse({ usernames: 'user1', logLevel: 'debug' })
+
+      expect(result.logLevel).toBe('debug')
+      // eslint-disable-next-line dot-notation
+      expect(process.env['LOG_LEVEL']).toBe('50')
+    })
+
+    it('should leave an existing LOG_LEVEL env var untouched when logLevel is not set', () => {
+      vi.stubEnv('LOG_LEVEL', '10')
+
+      globalOptsSchema.parse({ usernames: 'user1' })
+
+      // eslint-disable-next-line dot-notation
+      expect(process.env['LOG_LEVEL']).toBe('10')
+    })
   })
 
   it('should handle multiple usernames', () => {
@@ -267,6 +292,15 @@ describe('configSchema', () => {
     expect(() => configSchema.parse(invalidData)).toThrow()
   })
 
+  it('should throw an error if logLevel is not in the allowed enum values', () => {
+    const invalidData = {
+      usernames: ['user1'],
+      logLevel: 'verbose',
+    }
+
+    expect(() => configSchema.parse(invalidData)).toThrow()
+  })
+
   it('should allow empty arrays for optional list fields', () => {
     const dataWithEmptyArrays: Partial<Config> = {
       usernames: ['user1'],
@@ -318,6 +352,15 @@ describe('cliSchema', () => {
     const invalidData = {
       branch: 'develop',
       gitProvider: 'bitbucket',
+    }
+
+    expect(() => cliSchema.parse(invalidData)).toThrow()
+  })
+
+  it('should throw an error for invalid logLevel', () => {
+    const invalidData = {
+      usernames: 'user1',
+      logLevel: 'verbose',
     }
 
     expect(() => cliSchema.parse(invalidData)).toThrow()

--- a/src/utils/commands.spec.ts
+++ b/src/utils/commands.spec.ts
@@ -122,6 +122,20 @@ describe('parseOptions', () => {
     expect(result.usernames).toEqual(['config-user'])
   })
 
+  it('should resolve --log-level into the LOG_LEVEL env var before returning', () => {
+    // eslint-disable-next-line dot-notation
+    const originalLogLevel = process.env['LOG_LEVEL']
+
+    const result = parseOptions('global', { usernames: 'user1', logLevel: 'debug' })
+
+    expect(result.logLevel).toBe('debug')
+    // eslint-disable-next-line dot-notation
+    expect(process.env['LOG_LEVEL']).toBe('50')
+
+    // eslint-disable-next-line dot-notation
+    process.env['LOG_LEVEL'] = originalLogLevel
+  })
+
   it('should exit when the configuration file is invalid', () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -33,7 +33,6 @@ interface Options {
 export function parseOptions<T extends Cmd>(cmd: T, opts: Record<string, unknown>): Options[T] {
   log(`Initializing Docpress...`, 'info', 'blue')
   log(`\n\n-> Checking for required environment settings and configurations.`, 'info')
-  log(`   Debug info - opts: ${JSON.stringify(redactToken(opts))}`, 'debug')
   log(`   Debug info - cmd: ${cmd}`, 'debug')
 
   const res = globalOptsSchema.safeParse(opts)
@@ -41,6 +40,10 @@ export function parseOptions<T extends Cmd>(cmd: T, opts: Record<string, unknown
     log(`   An error occurred while checking configuration.\n     ${z.prettifyError(res.error)}`, 'error')
     process.exit(1)
   }
+  // Logged after validation (not the raw input) so this reflects the fully merged
+  // CLI/config/defaults result, and so a `--log-level debug` passed in this same
+  // invocation - only resolved inside the schema above - is already in effect.
+  log(`   Debug info - resolved options: ${JSON.stringify(redactToken(res.data))}`, 'debug')
   log('   Setup complete! Ready to process your documentation.', 'info')
   return res.data as Options[T]
 }

--- a/src/utils/functions.spec.ts
+++ b/src/utils/functions.spec.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { addLastUpdatedFrontmatter, checkHttpStatus, createDir, deepMerge, extractFiles, getMdFiles, getUserInfos, getUserRepos, isDir, isFile, isObject, loadConfigFile, prettify, prettifyEnum, redactToken, sanitizeSegment, splitByComma } from './functions.js'
+import { addLastUpdatedFrontmatter, checkHttpStatus, createDir, deepMerge, extractFiles, formatDuration, formatError, getMdFiles, getUserInfos, getUserRepos, isDir, isFile, isObject, loadConfigFile, prettify, prettifyEnum, redactToken, sanitizeSegment, splitByComma } from './functions.js'
 
 vi.mock('fs')
 
@@ -515,6 +515,33 @@ describe('redactToken', () => {
     const original = { token: 'secret' }
     redactToken(original)
     expect(original.token).toBe('secret')
+  })
+})
+
+describe('formatError', () => {
+  it('should return the message of an Error instance', () => {
+    expect(formatError(new Error('boom'))).toBe('boom')
+  })
+
+  it('should stringify a non-Error value', () => {
+    expect(formatError('plain string')).toBe('plain string')
+    expect(formatError({ code: 42 })).toBe('[object Object]')
+  })
+})
+
+describe('formatDuration', () => {
+  it('should format sub-second durations in milliseconds', () => {
+    expect(formatDuration(350)).toBe('350ms')
+  })
+
+  it('should format sub-minute durations in seconds with one decimal', () => {
+    expect(formatDuration(1200)).toBe('1.2s')
+    expect(formatDuration(59999)).toBe('60.0s')
+  })
+
+  it('should format minute-plus durations as "Xm 0Ys"', () => {
+    expect(formatDuration(65000)).toBe('1m 05s')
+    expect(formatDuration(600000)).toBe('10m 00s')
   })
 })
 

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -21,7 +21,7 @@ export async function checkHttpStatus(url: string): Promise<number> {
     const response = await fetch(url, { method: 'HEAD', redirect: 'manual' })
     return response.status
   } catch (error) {
-    log(`   Network error while checking '${url}': ${error instanceof Error ? error.message : String(error)}`, 'debug')
+    log(`   Network error while checking '${url}': ${formatError(error)}`, 'debug')
     return 500
   }
 }
@@ -52,6 +52,35 @@ export function redactToken<T extends { token?: unknown }>(obj: T): T {
     return obj
   }
   return { ...obj, token: obj.token ? '***' : obj.token } as T
+}
+
+/**
+ * Extracts a human-readable message from a caught value
+ *
+ * @param error - The caught value (typically an Error, but not guaranteed)
+ * @returns The error's message, or its string representation when it isn't an Error
+ */
+export function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Formats a duration in milliseconds as a short human-readable string
+ *
+ * @param ms - Duration in milliseconds
+ * @returns Formatted duration (e.g. "350ms", "1.2s", "1m 05s")
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`
+  }
+  const totalSeconds = ms / 1000
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.round(totalSeconds % 60)
+  return `${minutes}m ${String(seconds).padStart(2, '0')}s`
 }
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -55,6 +55,28 @@ const colorMap: ColorMap = {
 }
 
 /**
+ * Log level names selectable via the --log-level flag / logLevel config key,
+ * kept in sync with the numeric scale in colorMap ('success' excluded: it is
+ * not an independently selectable verbosity level, only an info-level color)
+ */
+export const LOG_LEVEL_NAMES = ['error', 'warn', 'info', 'trace', 'debug'] as const
+
+/**
+ * A log level name selectable via the --log-level flag / logLevel config key
+ */
+export type LogLevelName = typeof LOG_LEVEL_NAMES[number]
+
+/**
+ * Resolves the numeric LOG_LEVEL value for a named log level
+ *
+ * @param name - Log level name
+ * @returns The numeric level consumed by LOG_LEVEL / colorMap
+ */
+export function logLevelValue(name: LogLevelName): number {
+  return colorMap[name].level
+}
+
+/**
  * Logs a message with color formatting based on type and level
  *
  * @param msg - Message to log


### PR DESCRIPTION
## Summary

Add a `--log-level` flag, unify error handling across fetch/prepare/build, add timing/summary logging, and fix three bugs surfaced while dogfooding these changes.

## Purpose & Context

**Problem:** A review of the CLI's logging surfaced several gaps:
- `LOG_LEVEL` was a numeric env var with no CLI flag, undocumented, and invisible from `--help`.
- Each phase reported failures differently: `build` caught its own error, logged it, and called `process.exit(1)` itself; `fetch` tolerated per-user failures but only threw a generic error if *every* user failed; `prepare` had no error handling at all and fell through to a third, differently-formatted path.
- Long-running phases (fetch/prepare/build) gave no elapsed-time or success/failure summary — only failures got a message, successes were silent.
- Two differently-styled debug dumps logged the same options object at different points during option parsing.

**Solution:** See commits below. Each is self-contained and reviewable independently.

## Changes Made

**`feat(cli): add --log-level flag with config/env precedence`**
- New `--log-level <error|warn|info|trace|debug>` flag and matching `logLevel` config key, documented in `--help`.
- Precedence: CLI flag > config file > existing numeric `LOG_LEVEL` env var > default — fully backward compatible, existing `LOG_LEVEL=<n>` usage is untouched.
- Collapses two differently-styled debug dumps of the same options object into one, logged once after validation.

**`feat(cli): unify error handling and add timing/summary logging`**
- New `formatError()`/`formatDuration()` helpers (the error-formatting ternary was duplicated 8+ times).
- `build` now throws with context instead of logging/exiting itself; `cli.ts`'s top-level catch is the sole place that reports a failure and sets the exit code.
- `prepare` gets the same per-username partial-failure tolerance `fetch` already had.
- Octokit's `log.warn`/`log.error` output now routes through the shared logger so it respects `LOG_LEVEL` and gets consistent coloring. (The Vitepress build's intercepted `console.warn` warnings are deliberately *not* routed through the logger — see the `fix(build)` commit below for why that is unsafe.)
- fetch/prepare/build report elapsed time and success/failure counts.

**`fix(build): prevent console.warn recursion that crashed the Vitepress build`**
- The commit above routed the Vitepress build's non-suppressed `console.warn` output through `log()`. But `log()` itself writes via `console.warn` — the very function `suppressVueWarnings` overrides — so any non-suppressed warning during the build recursed until the stack overflowed. Vite's "chunks are larger than 500 kB" reporter warning (the mermaid bundle exceeds the limit) triggers it on every run, aborting with `[vite:reporter] Maximum call stack size exceeded` and failing all CLI CI jobs.
- Fix: forward non-suppressed warnings straight to the original `console.warn`. Added a regression test that gives the mocked logger a realistic `console.warn`-backed implementation, so the recursion is actually exercised (the previous test mocked `log` to a no-op, which is why the failure never showed up under test).

**`fix(prepare): fail clearly when the Vitepress template theme is missing`**
- `generateVitepressFiles()` silently copied zero theme files when the template source directory didn't exist, while still logging success. The Vitepress build would then fail minutes later with an opaque Vite `ENOENT`. Now throws immediately with the actual missing path.

**`fix(dev): set NODE_ENV=development for the dev script`**
- The `dev` script ran from source without `NODE_ENV=development`, so `TEMPLATE_THEME` resolved to a nonexistent path and hit the bug above on every local dev run.

**`docs: document --log-level flag and its precedence over LOG_LEVEL`**
- Regenerates the pasted `--help` block in README/docs, adds a "Log Level Selection" section.

## Testing

**Automated:** 297 tests pass (29 new/updated for this change, including the recursion regression test), `eslint`, `tsc`, and `vite build` all clean.
**End-to-end:** Reproduced the CI CLI test locally (`ci/scripts/run-tests.sh`) — packs the tgz, fresh-installs it under **npm, pnpm, and bun**, and runs a real `docpress -U this-is-tobi -r homelab` fetch→prepare→build. All three now report `Docpress build succeeded` and pass `checkDocsResult`.
**Manual:** Smoke-tested against a real GitHub account (`--help`, `--log-level debug`, and forced failures in each phase to confirm the unified exit path).

## Breaking Changes

None. All changes are additive or fix silent/inconsistent behavior; existing flags, config keys, and the `LOG_LEVEL` env var behave exactly as before when `--log-level`/`logLevel` aren't set.

## Additional Notes

The `[vite:reporter] Maximum call stack size exceeded` build failure that turned the first CI run of this PR red was **introduced by this PR**, not pre-existing — an earlier revision of this description mis-attributed it to a dependency bump on `main`, which was wrong. Root cause: the `console.warn` re-entrancy described in the `fix(build)` commit above, which is now fixed and covered by a regression test. A faithful local reproduction of the CI CLI job (fresh consumer install across npm/pnpm/bun) confirms the build now completes cleanly.
